### PR TITLE
Add minimal metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  # author: your name
+  # description: your description
+  company: CiscoUcs
+
+  license: Apache 2.0
+
+  min_ansible_version: 2.0
+
+  galaxy_tags: []
+
+dependencies: []


### PR DESCRIPTION
Hey, if you add the minimum metadata requirement then users can import this role

`ansible-galaxy install -r requirements.txt`
```
# requirements.txt
- name: imc-ansible
  #src: https://github.com/CiscoUcs/imc-ansible.git
  #version: f9645e844770e2f95b41a8f691f76f8078ca6216i
  src: https://github.com/kcd83/imc-ansible.git
  version: 6f947eede56daaa47670b2885cd7a6007969ab9c

```